### PR TITLE
Feature target encoding

### DIFF
--- a/app-examples/kissmda-app-test/pom.xml
+++ b/app-examples/kissmda-app-test/pom.xml
@@ -124,6 +124,7 @@
 					</transformerNameWithOrders>
 					<modelFile>src/main/resources/model/emf/test-uml.uml</modelFile>
 					<loggingLevel>SEVERE</loggingLevel>
+					<targetEncoding>UTF-8</targetEncoding>					
 				</configuration>
 			</plugin>
 			<plugin>

--- a/cartridges/kissmda-cartridges-simple-java/pom.xml
+++ b/cartridges/kissmda-cartridges-simple-java/pom.xml
@@ -29,7 +29,7 @@
 	
 	<groupId>de.crowdcode.kissmda.cartridges</groupId>
 	<artifactId>kissmda-cartridges-simple-java</artifactId>
-	<version>2.0.2</version>
+	<version>2.0.3</version>
 	<packaging>jar</packaging>
 	<name>kissmda-cartridges-simple-java</name>
 

--- a/cartridges/kissmda-cartridges-simple-java/pom.xml
+++ b/cartridges/kissmda-cartridges-simple-java/pom.xml
@@ -36,7 +36,7 @@
 	<properties>
 		<jukito.version>1.1</jukito.version>
         <junit.version>4.10</junit.version>
-        <kissmda.core.version>2.0.0</kissmda.core.version>
+        <kissmda.core.version>2.0.1</kissmda.core.version>
     </properties>
 
 	<dependencies>

--- a/core/kissmda-core/pom.xml
+++ b/core/kissmda-core/pom.xml
@@ -30,7 +30,7 @@
 
 	<groupId>de.crowdcode.kissmda.core</groupId>
 	<artifactId>kissmda-core</artifactId>
-	<version>2.0.0</version>
+	<version>2.0.1</version>
 	<packaging>jar</packaging>
 	<name>kissmda-core</name>
 

--- a/core/kissmda-core/src/main/java/de/crowdcode/kissmda/core/Context.java
+++ b/core/kissmda-core/src/main/java/de/crowdcode/kissmda/core/Context.java
@@ -41,6 +41,13 @@ public interface Context {
 	String getTargetModel();
 
 	/**
+	 * Get the target encoding.
+	 * 
+	 * @return targetEncoding as String
+	 */
+	String getTargetEncoding();
+
+	/**
 	 * Set source model.
 	 * 
 	 * @param sourceModel
@@ -53,4 +60,11 @@ public interface Context {
 	 * @param targetModel
 	 */
 	void setTargetModel(String targetModel);
+
+	/**
+	 * Set target encoding.
+	 * 
+	 * @param targetEncoding
+	 */
+	void setTargetEncoding(String targetEncoding);
 }

--- a/core/kissmda-core/src/main/java/de/crowdcode/kissmda/core/StandardContext.java
+++ b/core/kissmda-core/src/main/java/de/crowdcode/kissmda/core/StandardContext.java
@@ -27,6 +27,7 @@ package de.crowdcode.kissmda.core;
 public class StandardContext implements Context {
 	private String sourceModel;
 	private String targetModel;
+	private String targetEncoding;
 
 	/**
 	 * {@link Context #setSourceModel(String)}
@@ -45,6 +46,14 @@ public class StandardContext implements Context {
 	}
 
 	/**
+	 * {@link Context #getTargetEncoding()}
+	 */
+	@Override
+	public String getTargetEncoding() {
+		return targetEncoding;
+	}
+
+	/**
 	 * {@link Context #setSourceModel(String)}
 	 */
 	@Override
@@ -58,5 +67,13 @@ public class StandardContext implements Context {
 	@Override
 	public void setTargetModel(String targetModel) {
 		this.targetModel = targetModel;
+	}
+
+	/**
+	 * {@link Context #setTargetEncoding(String)}
+	 */
+	@Override
+	public void setTargetEncoding(String targetEncoding) {
+		this.targetEncoding = targetEncoding;
 	}
 }

--- a/core/kissmda-core/src/main/java/de/crowdcode/kissmda/core/file/FileWriter.java
+++ b/core/kissmda-core/src/main/java/de/crowdcode/kissmda/core/file/FileWriter.java
@@ -20,7 +20,9 @@ package de.crowdcode.kissmda.core.file;
 
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.Writer;
 
 import de.crowdcode.kissmda.core.Context;
@@ -47,19 +49,22 @@ public class FileWriter {
 	 *            the target content
 	 * @throws IOException
 	 */
-	public void createFile(final Context context, final String directory,
-			final String fileName, final String fileContent) throws IOException {
+	public void createFile(final Context context, final String directory, final String fileName,
+			final String fileContent) throws IOException {
 
-		String directoryToBeCreated = context.getTargetModel() + File.separator
-				+ directory;
+		String directoryToBeCreated = context.getTargetModel() + File.separator + directory;
 		new File(directoryToBeCreated).mkdirs();
 
 		// Create the class file
 		Writer writer = null;
 		try {
-			File file = new File(directoryToBeCreated + File.separator
-					+ fileName);
-			writer = new BufferedWriter(new java.io.FileWriter(file));
+			File file = new File(directoryToBeCreated + File.separator + fileName);
+			if (context.getTargetEncoding() != null) {
+				writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file),
+						context.getTargetEncoding()));
+			} else {
+				writer = new BufferedWriter(new java.io.FileWriter(file));
+			}
 			writer.write(fileContent);
 		} finally {
 			if (writer != null) {

--- a/kissmda-parent/pom.xml
+++ b/kissmda-parent/pom.xml
@@ -238,15 +238,4 @@
 			</build>
 		</profile>
 	</profiles>
-	  <distributionManagement>
-    <repository>
-      <id>releases</id>
-      <url>https://ers-build.deutschepost.dpwn.com:9443/nexus/content/repositories/thirdparty</url>
-    </repository>
-    <snapshotRepository>
-      <id>snapshots</id>
-      <url>https://ers-build.deutschepost.dpwn.com:9443/nexus/content/repositories/snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
-	
 </project>

--- a/kissmda-parent/pom.xml
+++ b/kissmda-parent/pom.xml
@@ -238,4 +238,15 @@
 			</build>
 		</profile>
 	</profiles>
+	  <distributionManagement>
+    <repository>
+      <id>releases</id>
+      <url>https://ers-build.deutschepost.dpwn.com:9443/nexus/content/repositories/thirdparty</url>
+    </repository>
+    <snapshotRepository>
+      <id>snapshots</id>
+      <url>https://ers-build.deutschepost.dpwn.com:9443/nexus/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+	
 </project>

--- a/maven/kissmda-maven-plugin/pom.xml
+++ b/maven/kissmda-maven-plugin/pom.xml
@@ -29,14 +29,14 @@
 	
 	<groupId>de.crowdcode.kissmda.maven</groupId>
 	<artifactId>kissmda-maven-plugin</artifactId>
-	<version>2.0.0</version>
+	<version>2.0.1</version>
 	<packaging>maven-plugin</packaging>
 	<name>kissmda-maven-plugin</name>
 	<description>KissMDA Maven plugin</description>
 
 	<properties>
 		<version.maven>2.0.9</version.maven>
-		<kissmda.core.version>2.0.0</kissmda.core.version>
+		<kissmda.core.version>2.0.1</kissmda.core.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 	</parent>
 	
 	<artifactId>kissmda-modules</artifactId>
-	<version>2.0.0</version>
+	<version>2.0.1</version>
 	<packaging>pom</packaging>
 
 	<!-- =============================================================== -->


### PR DESCRIPTION
Hallo Lofi,

ich habe endlich meine Änderungen an KissMDA in einen Branch eingecheckt.
Wir hatten Probleme mit Umlauten in Kommentaren, die nur auf dem Buildrecher auftraten. Scheinbar waren die settings des Betriebssystems schuld. Mit dem neuen Parameter ist das Encoding nicht mehr von externen Faktoren abhängig, sondern kann explizit gesetzt werden.

Weiterhin weden jetzt bei Enums die Beschreibungen (Javadoc) der Werte aus dem Modell übernommen.

Grüße,
Joachim