### PR TITLE
noerder-tuitje;added enforcer-plugin to release process

### DIFF
--- a/kissmda-parent/pom.xml
+++ b/kissmda-parent/pom.xml
@@ -250,7 +250,38 @@
 				</property>
 			</activation>
 			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-enforcer-plugin</artifactId>
+							<version>3.0.0-M1</version>
+							<executions>
+								<execution>
+									<id>enforce-no-snapshots</id>
+									<goals>
+										<goal>enforce</goal>
+									</goals>
+									<phase>generate-resources</phase>
+									<inherited>true</inherited>
+									<configuration>
+										<rules>
+											<requireReleaseDeps>
+												<message>No Snapshots Dependencies Allowed!</message>
+												<onlyWhenRelease>true</onlyWhenRelease>
+											</requireReleaseDeps>
+										</rules>
+										<fail>true</fail>
+									</configuration>
+								</execution>
+							</executions>
+						</plugin>
+					</plugins>
+				</pluginManagement>
 				<plugins>
+					<plugin>
+						<artifactId>maven-enforcer-plugin</artifactId>
+					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
added the enforcer plugin to the parent configuration. this is enabled with the release profile and will crash the build if any child module contains snapshot dependencies.